### PR TITLE
Promote Travis to Kinetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@
 
 ################################################################################
 
-# Use ubuntu trusty (14.04) with sudo privileges.
-dist: trusty
+dist: xenial
 sudo: required
 # Use depreciated env due to python conflicts
-group: deprecated-2017Q2
 language:
   - generic
 cache:
@@ -15,7 +13,7 @@ cache:
 # Configuration variables. 
 env:
   global:
-    - ROS_DISTRO=indigo
+    - ROS_DISTRO=kinetic
     - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
     - CI_SOURCE_PATH=$(pwd)
     - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall


### PR DESCRIPTION
This promotes the travis CI to Kinetic and will allow for actual validation of builds instead of failing before compilation.

As of this PR however, there are 0 differences between compiling & running on Indigo vs. Kinetic. Even so, things may change, so an Indigo devel branch is housed on the `devel_indigo` branch.